### PR TITLE
Invalid Curve: Fixed issue of taking default curve and updated code to handle bigger points

### DIFF
--- a/InvalidCurve/src/main/java/de/rub/nds/tlsbreaker/invalidcurve/ec/oracles/RealDirectMessageECOracle.java
+++ b/InvalidCurve/src/main/java/de/rub/nds/tlsbreaker/invalidcurve/ec/oracles/RealDirectMessageECOracle.java
@@ -38,6 +38,8 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.bouncycastle.util.BigIntegers;
+//################
+import de.rub.nds.modifiablevariable.util.ArrayConverter;
 
 /**
  *
@@ -52,6 +54,8 @@ public class RealDirectMessageECOracle extends ECOracle {
     private Point checkPoint;
 
     private byte[] checkPMS;
+
+    byte[] explicitPMS = new byte[100];
 
     /**
      *
@@ -90,10 +94,17 @@ public class RealDirectMessageECOracle extends ECOracle {
         y.setModification(BigIntegerModificationFactory.explicitValue(ecPoint.getFieldY().getData()));
         message.getComputations().setPublicKeyY(y);
 
-        // set explicit premaster secret value (X value of the resulting point
-        // coordinate)
+        // set explicit premaster secret value (X value of the resulting point coordinate)
+
+        // byte[] explicitPMS = BigIntegers.asUnsignedByteArray(curve.getModulus().bitLength() / Bits.IN_A_BYTE,
+        // secret);
+        // ADDED BELOW CODE BLOCK BECAUSE THERE WAS AN ISSUE bouncycastle IMPLEMENTATION WHEN PROCESSING BIGGER VALUES
+        // MAINLY IN THE CASE OF SECP521R1 POINTS.
         ModifiableByteArray pms = ModifiableVariableFactory.createByteArrayModifiableVariable();
-        byte[] explicitPMS = BigIntegers.asUnsignedByteArray(curve.getModulus().bitLength() / Bits.IN_A_BYTE, secret);
+        int elementLength = ArrayConverter.bigIntegerToByteArray(curve.getModulus()).length;
+        LOGGER.info("ELEMENT LENGTH" + elementLength);
+        byte[] explicitPMS = ArrayConverter.bigIntegerToNullPaddedByteArray(secret, elementLength);
+
         pms.setModification(ByteArrayModificationFactory.explicitValue(explicitPMS));
         message.getComputations().setPremasterSecret(pms);
 

--- a/InvalidCurve/src/main/java/de/rub/nds/tlsbreaker/invalidcurve/impl/InvalidCurveAttacker.java
+++ b/InvalidCurve/src/main/java/de/rub/nds/tlsbreaker/invalidcurve/impl/InvalidCurveAttacker.java
@@ -110,9 +110,13 @@ public class InvalidCurveAttacker extends Attacker<InvalidCurveAttackConfig> {
     @Override
     public void executeAttack() {
         Config tlsConfig = getTlsConfig();
-        LOGGER.info("Executing attack against the server with named curve {}",
-            tlsConfig.getDefaultSelectedNamedGroup().name());
-        EllipticCurve curve = CurveFactory.getCurve(tlsConfig.getDefaultSelectedNamedGroup());
+
+        NamedGroup invalidCurveAttackConfig_NamedGroup = config.getNamedGroup();
+
+        tlsConfig.setDefaultSelectedNamedGroup(invalidCurveAttackConfig_NamedGroup);
+        LOGGER.info("Executing attack against the server with named curve {}", invalidCurveAttackConfig_NamedGroup);
+        EllipticCurve curve = CurveFactory.getCurve(invalidCurveAttackConfig_NamedGroup);
+
         RealDirectMessageECOracle oracle = new RealDirectMessageECOracle(tlsConfig, curve);
         ICEAttacker attacker = new ICEAttacker(oracle, config.getServerType(), config.getAdditionalEquations(),
             tlsConfig.getDefaultSelectedNamedGroup());


### PR DESCRIPTION
1.Able to use other curves for the execution(earlier only secp256r1)
2. Found issue in bouncy castle code which was not able to analyse the bigger points(like secp521r1 points)