### PR TITLE
Error Handling in psk during server not supporting psk ciphers + code…

### DIFF
--- a/Breaker-Commons/src/main/java/de/rub/nds/tlsbreaker/breakercommons/util/pcap/ConsoleInteractor.java
+++ b/Breaker-Commons/src/main/java/de/rub/nds/tlsbreaker/breakercommons/util/pcap/ConsoleInteractor.java
@@ -259,12 +259,12 @@ public class ConsoleInteractor {
         }
     }
 
-    public String getValidUserSelectionForPSK(List<String> uniqueServers) {
+    public String getValidUserSelectionForPSKClient(List<String> uniqueServers) {
         if (uniqueServers.size() == 1) {
-            CONSOLE.info("Do you want to check the vulnerability of the server? (y/n):");
+            CONSOLE.info("Do you want to check the vulnerability of the Client? (y/n):");
             return getUserDecisionForOneServer();
         } else {
-            CONSOLE.info("Please select server numbers to check for vulnerability ");
+            CONSOLE.info("Please select a client number to check for vulnerability ");
             CONSOLE.info("Make Sure Client is Active");
             CONSOLE.info("Select Option: ");
             return getUserInputForMultipleServers(uniqueServers);

--- a/Client-PskBruteforcer/src/main/java/de/rub/nds/tlsbreaker/clientpskbruteforcer/impl/PskBruteForcerAttackClient.java
+++ b/Client-PskBruteforcer/src/main/java/de/rub/nds/tlsbreaker/clientpskbruteforcer/impl/PskBruteForcerAttackClient.java
@@ -117,6 +117,7 @@ public class PskBruteForcerAttackClient extends Attacker<PskBruteForcerAttackCli
                 }
             } else {
                 LOGGER.warn("Could not find the EncryptedRecord - attack stopped");
+                CONSOLE.warn("Client does not support PSK");
             }
         } else {
             LOGGER.warn("Did not receive ClientHello - attack stopped");
@@ -139,7 +140,11 @@ public class PskBruteForcerAttackClient extends Attacker<PskBruteForcerAttackCli
             }
         }
         tlsConfig.setEnforceSettings(true);
-        continueProtocolFlowToClient(state);
+        try {
+            continueProtocolFlowToClient(state);
+        } catch (Exception e) {
+            LOGGER.info("No PSK Cipher Supported");
+        }
         return state;
     }
 

--- a/Client-PskBruteforcer/src/main/java/de/rub/nds/tlsbreaker/clientpskbruteforcer/impl/PskBruteForcerClientPcapFileHandler.java
+++ b/Client-PskBruteforcer/src/main/java/de/rub/nds/tlsbreaker/clientpskbruteforcer/impl/PskBruteForcerClientPcapFileHandler.java
@@ -61,7 +61,7 @@ public class PskBruteForcerClientPcapFileHandler {
                 ConsoleInteractor consoleInteractor = new ConsoleInteractor();
                 consoleInteractor.displayClientWithServers(clientServers, uniqueClient);
 
-                String userOption = consoleInteractor.getValidUserSelectionForPSK(uniqueClient);
+                String userOption = consoleInteractor.getValidUserSelectionForPSKClient(uniqueClient);
                 if ("N".equals(userOption)) {
                     CONSOLE.info("Execution of the attack cancelled.");
                 } else if ("a".equals(userOption)) {
@@ -93,8 +93,10 @@ public class PskBruteForcerClientPcapFileHandler {
                         } else if ("N".equals(userResponse)) {
                             CONSOLE.info("Execution of the attack cancelled.");
                         }
+                    } else if (Objects.equals(vulnerability, Boolean.FALSE)) {
+                        CONSOLE.info("Client " + source + " is not vulnerable.");
                     } else {
-                        CONSOLE.info("The Client " + host + " is not vulnerable.");
+                        CONSOLE.warn("Vulnerable: Uncertain");
                     }
                 }
             } else {

--- a/Server-PskBruteforcer/src/main/java/de/rub/nds/tlsbreaker/serverpskbruteforce/Main.java
+++ b/Server-PskBruteforcer/src/main/java/de/rub/nds/tlsbreaker/serverpskbruteforce/Main.java
@@ -82,7 +82,7 @@ public class Main {
             try {
                 Boolean result = attacker.checkVulnerability();
                 if (Objects.equals(result, Boolean.TRUE)) {
-                    CONSOLE.error("Vulnerable:" + result.toString());
+                    CONSOLE.info("Vulnerable:" + result.toString());
                 } else if (Objects.equals(result, Boolean.FALSE)) {
                     CONSOLE.info("Vulnerable:" + result.toString());
                 } else {

--- a/Server-PskBruteforcer/src/main/java/de/rub/nds/tlsbreaker/serverpskbruteforce/impl/PskBruteForcerAttackServer.java
+++ b/Server-PskBruteforcer/src/main/java/de/rub/nds/tlsbreaker/serverpskbruteforce/impl/PskBruteForcerAttackServer.java
@@ -55,36 +55,37 @@ public class PskBruteForcerAttackServer extends Attacker<PskBruteForcerAttackSer
         CONSOLE.info("Connecting to the Server to find a PSK cipher suite he supports...");
         CipherSuite suite = getSupportedPskCipherSuite();
         if (suite == null) {
-            CONSOLE.info("Stopping attack");
-        }
-        CONSOLE.info("The server supports " + suite
-            + ". Trying to guess the PSK. This is an online Attack. Depending on the PSK this may take some time...");
-        guessProvider = GuessProviderFactory.createGuessProvider(config.getGuessProviderType(),
-            config.getGuessProviderInputStream());
-        boolean result = false;
-        int counter = 0;
-        long startTime = System.currentTimeMillis();
-        while (!result) {
-            byte[] guessedPsk = guessProvider.getGuess();
-            if (guessedPsk == null) {
-                CONSOLE.info("Could not find psk - attack stopped");
-                break;
-            }
-            if (guessedPsk.length == 0) {
-                continue;
-            }
-            counter++;
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Guessing: " + ArrayConverter.bytesToHexString(guessedPsk));
-            }
-            result = executeProtocolFlowToServer(suite, guessedPsk);
-            if (result) {
-                long stopTime = System.currentTimeMillis();
-                CONSOLE.info("Found the psk in "
-                    + String.format("%d min, %d sec", TimeUnit.MILLISECONDS.toMinutes(stopTime - startTime),
-                        TimeUnit.MILLISECONDS.toSeconds(stopTime - startTime)
-                            - TimeUnit.MINUTES.toSeconds(TimeUnit.MILLISECONDS.toMinutes(stopTime - startTime))));
-                CONSOLE.info("Guessed " + counter + " times");
+            CONSOLE.warn("Stopping attack");
+        } else {
+            CONSOLE.info("The server supports " + suite
+                + ". Trying to guess the PSK. This is an online Attack. Depending on the PSK this may take some time...");
+            guessProvider = GuessProviderFactory.createGuessProvider(config.getGuessProviderType(),
+                config.getGuessProviderInputStream());
+            boolean result = false;
+            int counter = 0;
+            long startTime = System.currentTimeMillis();
+            while (!result) {
+                byte[] guessedPsk = guessProvider.getGuess();
+                if (guessedPsk == null) {
+                    CONSOLE.info("Could not find psk - attack stopped");
+                    break;
+                }
+                if (guessedPsk.length == 0) {
+                    continue;
+                }
+                counter++;
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Guessing: " + ArrayConverter.bytesToHexString(guessedPsk));
+                }
+                result = executeProtocolFlowToServer(suite, guessedPsk);
+                if (result) {
+                    long stopTime = System.currentTimeMillis();
+                    CONSOLE.info("Found the psk in "
+                        + String.format("%d min, %d sec", TimeUnit.MILLISECONDS.toMinutes(stopTime - startTime),
+                            TimeUnit.MILLISECONDS.toSeconds(stopTime - startTime)
+                                - TimeUnit.MINUTES.toSeconds(TimeUnit.MILLISECONDS.toMinutes(stopTime - startTime))));
+                    CONSOLE.info("Guessed " + counter + " times");
+                }
             }
         }
     }
@@ -98,7 +99,7 @@ public class PskBruteForcerAttackServer extends Attacker<PskBruteForcerAttackSer
         CONSOLE.info("Connecting to the Server...");
         boolean supportsPsk = getSupportedPskCipherSuite() != null;
         if (supportsPsk) {
-            CONSOLE.info("Maybe vulnerable - server supports PSK");
+            CONSOLE.info("Server supports PSK");
             return true;
         } else {
             CONSOLE.info("Not Vulnerable - server does not support PSK");

--- a/Server-PskBruteforcer/src/main/java/de/rub/nds/tlsbreaker/serverpskbruteforce/impl/PskBruteForcerPcapFileHandler.java
+++ b/Server-PskBruteforcer/src/main/java/de/rub/nds/tlsbreaker/serverpskbruteforce/impl/PskBruteForcerPcapFileHandler.java
@@ -79,8 +79,10 @@ public class PskBruteForcerPcapFileHandler {
                         } else if ("N".equals(userResponse)) {
                             CONSOLE.info("Execution of the attack cancelled.");
                         }
+                    } else if (Objects.equals(vulnerability, Boolean.FALSE)) {
+                        CONSOLE.info("Server " + host + " is not vulnerable.");
                     } else {
-                        CONSOLE.info("The server " + host + " is not vulnerable.");
+                        CONSOLE.warn("Vulnerable: Uncertain");
                     }
                 }
             } else {
@@ -173,7 +175,7 @@ public class PskBruteForcerPcapFileHandler {
         try {
             result = attacker.checkVulnerability();
             if (Objects.equals(result, Boolean.TRUE)) {
-                CONSOLE.error("Vulnerable:" + result.toString());
+                CONSOLE.info("Vulnerable:" + result.toString());
             } else if (Objects.equals(result, Boolean.FALSE)) {
                 CONSOLE.info("Vulnerable:" + result.toString());
             } else {


### PR DESCRIPTION
… cleaning.

Fixing : when the server is not supported psk, during normal -executeAttack execution this scenario was not handled properly.
Handled for both Server and Client PSK