### PR TITLE
Add Javadoc to public methods in de.rub.nds.tlsbreaker.breakercommons.config.delegate

### DIFF
--- a/Breaker-Commons/src/main/java/de/rub/nds/tlsbreaker/breakercommons/config/delegate/AttackDelegate.java
+++ b/Breaker-Commons/src/main/java/de/rub/nds/tlsbreaker/breakercommons/config/delegate/AttackDelegate.java
@@ -23,7 +23,9 @@ public class AttackDelegate extends Delegate {
                             + "executed (WARNING)")
     private boolean executeAttack = false;
 
-    /** Default Constructor */
+    /**
+     * Default constructor for AttackDelegate.
+     */
     public AttackDelegate() {}
 
     /**

--- a/Breaker-Commons/src/main/java/de/rub/nds/tlsbreaker/breakercommons/config/delegate/ClientDelegate.java
+++ b/Breaker-Commons/src/main/java/de/rub/nds/tlsbreaker/breakercommons/config/delegate/ClientDelegate.java
@@ -31,17 +31,37 @@ public class ClientDelegate extends Delegate {
 
     private int extractedPort;
 
+    /**
+     * Default constructor for ClientDelegate.
+     */
     public ClientDelegate() {}
 
+    /**
+     * Returns the configured host connection string.
+     *
+     * @return the host connection string in format "host:port"
+     */
     public String getHost() {
         return host;
     }
 
+    /**
+     * Sets the host connection string and extracts host and port parameters.
+     *
+     * @param host the host connection string in format "host:port"
+     */
     public void setHost(String host) {
         this.host = host;
         extractParameters();
     }
 
+    /**
+     * Applies this delegate configuration to the provided Config object.
+     * Configures the client connection with host, port, and optional SNI hostname.
+     *
+     * @param config the Config object to apply the delegate settings to
+     * @throws com.beust.jcommander.ParameterException if host format is invalid
+     */
     @Override
     public void applyDelegate(Config config) {
         extractParameters();
@@ -119,18 +139,38 @@ public class ClientDelegate extends Delegate {
         }
     }
 
+    /**
+     * Returns the configured SNI hostname.
+     *
+     * @return the SNI hostname, or null if not set
+     */
     public String getSniHostname() {
         return sniHostname;
     }
 
+    /**
+     * Sets the SNI hostname for the Server Name Indication extension.
+     *
+     * @param sniHostname the SNI hostname to use
+     */
     public void setSniHostname(String sniHostname) {
         this.sniHostname = sniHostname;
     }
 
+    /**
+     * Returns the host extracted from the connection string.
+     *
+     * @return the extracted host
+     */
     public String getExtractedHost() {
         return extractedHost;
     }
 
+    /**
+     * Returns the port extracted from the connection string.
+     *
+     * @return the extracted port number
+     */
     public int getExtractedPort() {
         return extractedPort;
     }

--- a/Breaker-Commons/src/main/java/de/rub/nds/tlsbreaker/breakercommons/config/delegate/GeneralAttackDelegate.java
+++ b/Breaker-Commons/src/main/java/de/rub/nds/tlsbreaker/breakercommons/config/delegate/GeneralAttackDelegate.java
@@ -18,7 +18,9 @@ public class GeneralAttackDelegate extends GeneralDelegate {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    /** Default Constructor */
+    /**
+     * Default constructor for GeneralAttackDelegate.
+     */
     public GeneralAttackDelegate() {}
 
     /**

--- a/Breaker-Commons/src/main/java/de/rub/nds/tlsbreaker/breakercommons/config/delegate/ProxyDelegate.java
+++ b/Breaker-Commons/src/main/java/de/rub/nds/tlsbreaker/breakercommons/config/delegate/ProxyDelegate.java
@@ -28,6 +28,13 @@ public class ProxyDelegate extends Delegate {
                     "Specify the host and port for control messages used in the proxy. Syntax: localhost:5555")
     private String proxyControl = "localhost:5555";
 
+    /**
+     * Applies this delegate configuration to the provided Config object.
+     * Configures the proxy settings for both data and control connections.
+     *
+     * @param config the Config object to apply the delegate settings to
+     * @throws com.beust.jcommander.ParameterException if proxy data format is invalid
+     */
     @Override
     public void applyDelegate(Config config) {
 
@@ -77,10 +84,20 @@ public class ProxyDelegate extends Delegate {
         return port;
     }
 
+    /**
+     * Sets the proxy data connection string.
+     *
+     * @param proxyData the proxy data connection string in format "host:port"
+     */
     public void setProxyData(String proxyData) {
         this.proxyData = proxyData;
     }
 
+    /**
+     * Sets the proxy control connection string.
+     *
+     * @param proxyControl the proxy control connection string in format "host:port"
+     */
     public void setProxyControl(String proxyControl) {
         this.proxyControl = proxyControl;
     }

--- a/Breaker-Commons/src/main/java/de/rub/nds/tlsbreaker/breakercommons/config/delegate/ServerDelegate.java
+++ b/Breaker-Commons/src/main/java/de/rub/nds/tlsbreaker/breakercommons/config/delegate/ServerDelegate.java
@@ -30,16 +30,36 @@ public class ServerDelegate extends Delegate {
     @Parameter(names = "-port", description = "ServerPort")
     private Integer port = null;
 
+    /**
+     * Default constructor for ServerDelegate.
+     */
     public ServerDelegate() {}
 
+    /**
+     * Returns the configured server port.
+     *
+     * @return the server port number, or null if not set
+     */
     public Integer getPort() {
         return port;
     }
 
+    /**
+     * Sets the server port to the specified value.
+     *
+     * @param port the port number to set
+     */
     public void setPort(int port) {
         this.port = port;
     }
 
+    /**
+     * Applies this delegate configuration to the provided Config object.
+     * Sets up the server configuration with the specified port.
+     *
+     * @param config the Config object to apply the delegate settings to
+     * @throws com.beust.jcommander.ParameterException if the port is not set or is invalid
+     */
     @Override
     public void applyDelegate(Config config) {
 


### PR DESCRIPTION
## Summary
- Added Javadoc documentation to all public methods in the de.rub.nds.tlsbreaker.breakercommons.config.delegate package
- Updated existing documentation to follow proper Javadoc format
- Each class was committed separately for easier review