### PR TITLE
Add Javadoc to public methods in drownattack.pkcs1.oracles package

### DIFF
--- a/Drown/src/main/java/de/rub/nds/tlsbreaker/drownattack/pkcs1/oracles/ExtraClearDrownOracle.java
+++ b/Drown/src/main/java/de/rub/nds/tlsbreaker/drownattack/pkcs1/oracles/ExtraClearDrownOracle.java
@@ -46,6 +46,12 @@ public class ExtraClearDrownOracle extends Pkcs1Oracle {
         public State state;
     }
 
+    /**
+     * Constructs a new ExtraClearDrownOracle for testing PKCS conformity using the extra clear
+     * oracle vulnerability.
+     *
+     * @param tlsConfig The TLS configuration containing SSL2 cipher suite settings
+     */
     public ExtraClearDrownOracle(Config tlsConfig) {
         this.tlsConfig = tlsConfig;
         cipherSuite = tlsConfig.getDefaultSSL2CipherSuite();


### PR DESCRIPTION
## Summary
- Added missing Javadoc documentation to the ExtraClearDrownOracle constructor
- All public methods in the de.rub.nds.tlsbreaker.drownattack.pkcs1.oracles package now have proper Javadoc